### PR TITLE
Use pathlib for filesystem operations

### DIFF
--- a/save_issues.py
+++ b/save_issues.py
@@ -1,3 +1,4 @@
+import mimetypes
 import os
 import re
 import requests
@@ -28,7 +29,9 @@ def download_and_save_image(url, issue_number):
     try:
         response = requests.get(url)
         if response.status_code == 200:
-            image_name = Path(url).name
+            mime_type = response.headers['Content-Type']
+            extension = mimetypes.guess_extension(mime_type)
+            image_name = Path(f"{url}{extension}").name
             image_folder = image_root / f'issue-{issue_number}'
             image_folder.mkdir(parents=True, exist_ok=True)
             path = image_folder / image_name

--- a/save_issues.py
+++ b/save_issues.py
@@ -1,6 +1,13 @@
 import os
 import re
 import requests
+from pathlib import Path
+
+# create the default image directory, if it doesn't exist
+image_root = Path('images')
+image_root.mkdir(parents=True, exist_ok=True)
+# change this if you want to save the markdown files to a subdirectory
+markdown_root = Path.cwd()
 
 def get_issues(repo, token, label):
     url = f"https://api.github.com/repos/{repo}/issues"
@@ -21,14 +28,13 @@ def download_and_save_image(url, issue_number):
     try:
         response = requests.get(url)
         if response.status_code == 200:
-            image_name = url.split("/")[-1]
-            image_folder = f'images/issue-{issue_number}'
-            if not os.path.exists(image_folder):
-                os.makedirs(image_folder)
-            path = os.path.join(image_folder, image_name)
-            with open(path, 'wb') as file:
-                file.write(response.content)
-            return path
+            image_name = Path(url).name
+            image_folder = image_root / f'issue-{issue_number}'
+            image_folder.mkdir(parents=True, exist_ok=True)
+            path = image_folder / image_name
+            path.write_bytes(response.content)
+            # return the file path as a string for our markdown file
+            return str(path)
         else:
             print(f"Failed to download image: {url}")
             return None
@@ -38,17 +44,18 @@ def download_and_save_image(url, issue_number):
 
 def save_issue(issue):
     try:
-        title = issue.get('title', 'Untitled').replace(' ', '_')
-        filename = f"{issue.get('number', 'Unknown')}_{title}.md"
-        with open(filename, 'w') as file:
-            file.write(f"# {issue.get('title', 'Untitled')}\n\n")
-            body = issue.get('body', '')
-            image_urls = extract_image_urls(body)
-            for url in image_urls:
-                image_path = download_and_save_image(url, issue['number'])
-                if image_path:
-                    body = body.replace(url, image_path)
-            file.write(body)
+        issue_number = issue.get('number', 'Unknown')
+        issue_title = issue.get('title', 'Untitled')
+        issue_body = issue.get('body', '')
+        md_filename = f"{issue_number}_{issue_title}.md".replace(' ', '_')
+        md_file = markdown_root / md_filename
+        md_file.write_text(f"# {issue_title}\n\n")
+        image_urls = extract_image_urls(issue_body)
+        for url in image_urls:
+            image_path = download_and_save_image(url, issue_number)
+            if image_path:
+                issue_body = issue_body.replace(url, image_path)
+        md_file.write_text(issue_body)
     except Exception as e:
         print(f"Error processing issue: {e}")
 

--- a/save_issues.py
+++ b/save_issues.py
@@ -29,12 +29,14 @@ def download_and_save_image(url, issue_number):
     try:
         response = requests.get(url)
         if response.status_code == 200:
-            mime_type = response.headers['Content-Type']
-            extension = mimetypes.guess_extension(mime_type)
-            image_name = Path(f"{url}{extension}").name
+            image_name = Path(f"{url}").name
             image_folder = image_root / f'issue-{issue_number}'
             image_folder.mkdir(parents=True, exist_ok=True)
             path = image_folder / image_name
+            if not path.suffix:
+                mime_type = response.headers['Content-Type']
+                extension = mimetypes.guess_extension(mime_type)
+                path = path.with_suffix(extension)
             path.write_bytes(response.content)
             # return the file path as a string for our markdown file
             return str(path)

--- a/save_issues.py
+++ b/save_issues.py
@@ -7,8 +7,9 @@ from pathlib import Path
 # create the default image directory, if it doesn't exist
 image_root = Path('images')
 image_root.mkdir(parents=True, exist_ok=True)
-# change this if you want to save the markdown files to a subdirectory
-markdown_root = Path.cwd()
+# create the default issues directory, if it doesn't exist.
+markdown_root = Path('issues')
+markdown_root.mkdir(parents=True, exist_ok=True)
 
 def get_issues(repo, token, label):
     url = f"https://api.github.com/repos/{repo}/issues"


### PR DESCRIPTION
- Use `pathlib.Path` to create directories, check whether files exist, and write to files.
- Use `mimetypes` to guess image file extensions from the response `Content-Type`, when an image URL doesn't have an extension.
- Save the markdown files in an `issues` directory.

`pathlib.Path` is the new filesystem library in recent versions of Python 3. Have a look at https://github.com/eatyourgreens/issues-to-markdown-action/pull/14 for an example of a PR that I generated with this branch.
